### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       steps:
         -
           name: Checkout
-          uses: actions/checkout@v4.1.7
+          uses: actions/checkout@v4.2.0
           with:
             # [Required] Access token with `workflow` scope.
             token: ${{ secrets.WORKFLOW_SECRET }}
@@ -36,7 +36,7 @@ jobs:
           # https://github.com/docker/buildx/issues/136#issuecomment-550205439
           # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
           name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3.6.1
+          uses: docker/setup-buildx-action@v3.7.0
           with:
             buildkitd-config: .github/buildkitd.toml
             driver-opts: |
@@ -58,7 +58,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v6.7.0
+          uses: docker/build-push-action@v6.9.0
           with:
             context: .
             build-args: |

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
         -
             name: Checkout
-            uses: actions/checkout@v4.1.7
+            uses: actions/checkout@v4.2.0
             with:
                 # [Required] Access token with `workflow` scope.
                 token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.9.0](https://github.com/docker/build-push-action/releases/tag/v6.9.0)** on 2024-09-30T09:51:48Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.7.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.7.0)** on 2024-10-03T07:33:36Z
